### PR TITLE
Prevent FileSystemNotFound exceptions when reading resource files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <artifactId>syllable-counter</artifactId>
 
-    <version>4.0.1</version>
+    <version>4.0.2</version>
 
     <packaging>jar</packaging>
 

--- a/src/test/java/eu/crydee/syllablecounter/SyllableCounterTest.java
+++ b/src/test/java/eu/crydee/syllablecounter/SyllableCounterTest.java
@@ -15,14 +15,9 @@
  */
 package eu.crydee.syllablecounter;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.stream.Stream;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  *
@@ -34,16 +29,6 @@ public class SyllableCounterTest {
             = "/eu/crydee/syllablecounter/english-exceptions.txt",
             TEST_PATH
             = "/eu/crydee/syllablecounter/english-test.txt";
-
-    private Stream<String> getRessourceLines(String filepath) {
-        try {
-            return Files.lines(
-                    Paths.get(getClass().getResource(filepath).toURI()),
-                    StandardCharsets.UTF_8);
-        } catch (URISyntaxException | IOException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
 
     /**
      * Test of count method, of class SyllableCounter.
@@ -74,7 +59,7 @@ public class SyllableCounterTest {
 
     private void testFromFile(String filepath) {
         SyllableCounter sc = new SyllableCounter();
-        getRessourceLines(filepath).filter(line -> !line.isEmpty())
+        sc.getRessourceLines(getClass(), filepath).filter(line -> !line.isEmpty())
                 .filter(line -> !line.startsWith("#"))
                 .forEach(line -> {
                     String[] fields = line.split(" ");


### PR DESCRIPTION
Hi @m09 ,

I'm trying to use your library in a distributed Spark environment. While everything works fine in my local testing, I'm running into a `FileSystemNotFoundException` when deploying to production:

```
11:33:11 Caused by: java.nio.file.FileSystemNotFoundException
11:33:11 	at com.sun.nio.zipfs.ZipFileSystemProvider.getFileSystem(ZipFileSystemProvider.java:171)
11:33:11 	at com.sun.nio.zipfs.ZipFileSystemProvider.getPath(ZipFileSystemProvider.java:157)
11:33:11 	at java.nio.file.Paths.get(Paths.java:143)
11:33:11 	at eu.crydee.syllablecounter.SyllableCounter.getRessourceLines(SyllableCounter.java:62)
11:33:11 	at eu.crydee.syllablecounter.SyllableCounter.<init>(SyllableCounter.java:70)
11:33:11 	... 36 more
```
So I've made a small modification to the code which uses `getResourceAsStream` to set up the file system implicitly. This is based on the StackOverflow answer found [here](https://stackoverflow.com/a/35644834).

Thanks.
-Tim